### PR TITLE
bump-deps: 2026-05-12 (uuid 14 CVE fix, CI action majors, Node 20 patch)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     concurrency: deploy-group # optional: ensure only one action runs at a time
     steps:
       - uses: actions/checkout@v4
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@v1.5
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: deploy-group # optional: ensure only one action runs at a time
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: superfly/flyctl-actions/setup-flyctl@v1.5
       - run: flyctl deploy --remote-only
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
         node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.18.0
+ARG NODE_VERSION=20.20.2
 FROM node:${NODE_VERSION}-slim AS base
 
 LABEL fly_launch_runtime="Node.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "express": "^5.2.1",
         "morgan": "^1.10.1",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "jest": "^30.4.2",
@@ -50,6 +50,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2895,6 +2896,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5451,11 +5453,13 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -5567,9 +5571,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -6348,6 +6352,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -6428,9 +6433,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6496,6 +6501,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "express": "^5.2.1",
     "morgan": "^1.10.1",
-    "uuid": "^13.0.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "jest": "^30.4.2",


### PR DESCRIPTION
## Summary

Coordinated dependency sweep produced by `/bump-deps`. Seven bumps applied, **0 regressions** (tests still 21/21), **0 vulnerabilities** remaining (`npm audit` was 1 direct + 3 transitive before).

| # | Change | Risk | CVE |
|---|--------|------|-----|
| 1 | `Dockerfile` Node base `20.18.0 → 20.20.2` (Iron LTS patch) | low | — |
| 2 | `superfly/flyctl-actions/setup-flyctl@master → @v1.5` (pin floating ref) | low | — |
| 3 | `actions/checkout @v4 → @v6` in `deploy.yml` | medium | — |
| 4 | `actions/checkout @v3 → @v6` + `actions/setup-node @v3 → @v6` in `test.yml` | high | — |
| 5 | `dependabot/fetch-metadata @v1 → @v3` | high | — |
| 6 | CI matrix `node-version [18.x, 20.x] → [20.x, 22.x]` (Node 18 is EOL 2025-04-30) | high | — |
| 7 | `uuid ^13.0.0 → ^14.0.0` + lockfile refresh | medium | **GHSA-w5hq-g745-h8pq** (uuid) + 3 transitive |

## Why

- **uuid v14 (#7)** fixes [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (moderate, bounds-check on `buf` arg). Not exploitable here — `api/v3.js` and `api/v4.js` never pass `buf` — but the bump eliminates the advisory and futureproofs the lib. v14 drops Node 18 and requires a global `crypto` (Node 20+); both prerequisites are satisfied by #1 and #6 on this branch.
- The same `npm install` refreshed the lockfile and silently picked up fixes for three express-transitive advisories:
  - `path-to-regexp 8.2.0 → 8.4.2`: [GHSA-j3q9-mxjg-w52f](https://github.com/advisories/GHSA-j3q9-mxjg-w52f) (high, ReDoS) and [GHSA-27v5-c462-wpq7](https://github.com/advisories/GHSA-27v5-c462-wpq7) (moderate, ReDoS)
  - `qs 6.14.1 → 6.15.1`: [GHSA-w7fw-mjwx-w883](https://github.com/advisories/GHSA-w7fw-mjwx-w883) (low, DoS)
- The action majors (#3–#5) were 2–3 majors behind. v4 dropped the Node16 runner; v5/v6 run on Node24. `ubuntu-latest` already provides Node24, so the workflows continue to work unchanged. For `dependabot/fetch-metadata`, both v2 and v3 are runner-only bumps — the `update-type` output that `dependabot-auto-merge.yml` consumes is unchanged.
- `@master` on `setup-flyctl` (#2) was a supply-chain risk — replaced with the most recent tag (`v1.5`).
- Node 18 left the matrix (#6) because it reached EOL on 2025-04-30 and is a prerequisite for uuid v14.

## Reviewer notes

- Each bump is one commit with a self-contained message citing its anchored source (release notes URL / `gh api` / `npm audit --json`). Reviewing commit-by-commit is the easiest way to read this PR.
- **Deferred (not in this PR):** Dockerfile Node `20 → 22` (Jod LTS). It's a runtime major affecting the deployed Fly image and was flagged in the plan for a deliberate, human-reviewed change instead.
- **Worth noting (also not in this PR):** `wrangler` is in `devDependencies` but has no `wrangler.toml` and no source usage — appears vestigial. Default `npm install` actually fails on its transitive `sharp` postinstall (all installs in this run used `--ignore-scripts`). Removing `wrangler` would clean up the install path; happy to do that as a follow-up if you agree.

## Test plan

- [x] `npm test` on baseline — 21/21 pass, 0 skip
- [x] `npm test` after each bump — 21/21 pass, no regressions
- [x] `npm audit` after the run — 0 vulnerabilities
- [ ] CI green on this PR across both Node 20 and Node 22 matrix entries (this also exercises the upgraded `actions/checkout@v6` + `actions/setup-node@v6`)
- [ ] Confirm `dependabot/fetch-metadata@v3` still emits `outputs.update-type` correctly on the next Dependabot PR (auto-merge logic depends on it)
- [ ] Confirm Fly deploy on merge — exercises the Dockerfile Node patch and the upgraded `actions/checkout@v6` + `setup-flyctl@v1.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)