### PR TITLE
fix(ci): correct flyctl-actions tag — @v1.5 doesn't exist, use @v1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     concurrency: deploy-group # optional: ensure only one action runs at a time
     steps:
       - uses: actions/checkout@v6
-      - uses: superfly/flyctl-actions/setup-flyctl@v1.5
+      - uses: superfly/flyctl-actions/setup-flyctl@v1
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

Hotfix for the deploy failure introduced by #130:

```
Error: Unable to resolve action `superfly/flyctl-actions@v1.5`, unable to find version `v1.5`
```

The pin I introduced in #130 used the GitHub *release name* (`"v1.5"`), but on `superfly/flyctl-actions` the actual git tags for the 1.x line are **unprefixed**: `1.0`, `1.1`, …, `1.5`, `1.6`. Only the rolling major is prefixed (`v1`). GitHub Actions resolves by tag, not release name, so `@v1.5` 404s.

## Fix

Move to `@v1` — the rolling major tag, same shape we already use for `actions/checkout@v6` etc. It floats within the v1.x line (narrower than the original `@master`, which floated across the whole repo) and is the idiomatic pin for GitHub Actions.

If you'd prefer a hard pin instead, the equivalent specific-version pin would be `@1.6` (latest 1.x release, no `v`).

## Why this slipped through

`/bump-deps` validation runs the Node test suite after each bump, but the deploy workflow only runs on `push` to `main` — so the broken tag wasn't exercised until merge. Worth a follow-up: change the trigger on `deploy.yml` to also run on `pull_request: [main]` for `paths: ['.github/workflows/deploy.yml']`, so future workflow edits get parsed by Actions during PR review.

## Test plan

- [ ] Deploy workflow on this PR (well, on merge) successfully resolves `superfly/flyctl-actions/setup-flyctl@v1` and reaches the `flyctl deploy` step
- [ ] Fly deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)